### PR TITLE
Version Name y Pool List :ok_hand:

### DIFF
--- a/src/Settings/Settings.cpp
+++ b/src/Settings/Settings.cpp
@@ -71,7 +71,7 @@ const quint64 DEFAULT_OPTIMIZATION_MIXIN = 0;
 
 const char* VERSION_NAME = "Phoenix";
 const quint64 VERSION_MAJOR = 1;
-const quint64 VERSION_MINOR = 3;
+const quint64 VERSION_MINOR = 4;
 const quint64 VERSION_PATCH = 0;
 
 }
@@ -83,7 +83,7 @@ Settings& Settings::instance() {
 
 
 Settings::Settings() : m_p2pBindPort(0), m_cmdLineParser(nullptr) {
-  m_defaultPoolList << "stratum01.cryptoluka.cl:9991";
+  m_defaultPoolList << "stratum01.cryptoluka.cl:9991" << "luk.cryptonote.club:3333" << "luk.cryptonote.club:4444" << "luk.cryptonote.club:5555";
 
   Style* lightStyle = new LightStyle();
   Style* darkStyle = new DarkStyle();


### PR DESCRIPTION
Se añadió la version en v1.4.0 Phoenix y el default pool list con las siguientes direcciones y puertos de las siguientes diff:

- "luk.cryptonote.club:3333" 
- "luk.cryptonote.club:4444" 
- "luk.cryptonote.club:5555" 

Verificar igualmente si está correcto.